### PR TITLE
Update ldapauthenticator from 1.3.2 to 2.0.0.b2

### DIFF
--- a/images/hub/requirements.in
+++ b/images/hub/requirements.in
@@ -12,7 +12,7 @@ jupyterhub==5.2.0
 ## Authenticators
 jupyterhub-firstuseauthenticator>=1
 jupyterhub-hmacauthenticator
-jupyterhub-ldapauthenticator
+jupyterhub-ldapauthenticator==2.0.0.b2
 jupyterhub-ltiauthenticator!=1.3.0
 jupyterhub-nativeauthenticator
 jupyterhub-tmpauthenticator

--- a/images/hub/requirements.txt
+++ b/images/hub/requirements.txt
@@ -96,7 +96,7 @@ jupyterhub-idle-culler==1.4.0
     # via -r requirements.in
 jupyterhub-kubespawner==7.0.0b3
     # via -r requirements.in
-jupyterhub-ldapauthenticator==1.3.2
+jupyterhub-ldapauthenticator==2.0.0b2
     # via -r requirements.in
 jupyterhub-ltiauthenticator==1.6.2
     # via -r requirements.in
@@ -233,7 +233,6 @@ tornado==6.4.1
     # via
     #   jupyterhub
     #   jupyterhub-idle-culler
-    #   jupyterhub-ldapauthenticator
     #   oauthenticator
 traitlets==5.14.3
     # via


### PR DESCRIPTION
Since we're putting out another Z2JH beta we might as well include the ldapauthenticator beta